### PR TITLE
Use the public api alb

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -26,7 +26,7 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
 }
 
 data "aws_lb" "filing_maintain_lb" {
-  name = "${var.environment}-chs-chgovuk"
+  name = "${var.environment}-chs-apichgovuk"
 }
 
 data "aws_lb_listener" "filing_maintain_lb_listener" {


### PR DESCRIPTION
This pr changes the alb the service uses to be the external chs api one. This is because the service will eventually be opened to external api users.