### PR TITLE
Fix healthcheck in terraform

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -6,7 +6,7 @@ locals {
   container_port            = "3000" # default port required here until prod docker container is built allowing port change via env var
   docker_repo               = "accounts-filing-api"
   lb_listener_rule_priority = 15
-  lb_listener_paths         = ["/accounts-filing.*", "/transaction/.*/accounts-filing.*"]
+  lb_listener_paths         = ["/accounts-filing.*", "/transactions/.*/accounts-filing.*"]
   healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
   healthcheck_matcher       = "200"
 

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -3,12 +3,12 @@ locals {
   stack_name                = "filing-maintain" # this must match the stack name the service deploys into
   name_prefix               = "${local.stack_name}-${var.environment}"
   service_name              = "accounts-filing-api"
-  container_port            = "3000" # default node port required here until prod docker container is built allowing port change via env var
+  container_port            = "3000" # default port required here until prod docker container is built allowing port change via env var
   docker_repo               = "accounts-filing-api"
   lb_listener_rule_priority = 15
-  lb_listener_paths         = ["/accounts-filing.*"]
-  healthcheck_path          = "/actuator/health" #healthcheck path for accounts-filing-api
-  healthcheck_matcher       = "200"  # no explicit healthcheck in this service yet, change this when added!
+  lb_listener_paths         = ["/accounts-filing.*", "/transaction/.*/accounts-filing.*"]
+  healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
+  healthcheck_matcher       = "200"
 
   kms_alias       = "alias/${var.aws_profile}/environment-services-kms"
   service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)


### PR DESCRIPTION
This pr fixes the healthcheck to be the bespoke built one, plus adds transactions to the list of listener paths.