### PR TITLE
Fix config for the internal api client

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/ApplicationConfiguration.java
@@ -29,14 +29,12 @@ public class ApplicationConfiguration {
     public InternalApiClient internalApiClient(
             @Value("${api.base.path}") String apiBasePath,
             @Value("${internal.api.base.path}") String internalApiBasePath,
-            @Value("${payments.api.base.path}") String paymentsApiBasePath,
             @Value("${internal.api.key}") String internalApiKey
     ) {
         ApiKeyHttpClient httpClient = new ApiKeyHttpClient(internalApiKey);
         InternalApiClient internalApiClient = new InternalApiClient(httpClient);
 
         internalApiClient.setBasePath(internalApiBasePath);
-        internalApiClient.setBasePaymentsPath(paymentsApiBasePath);
         internalApiClient.setInternalBasePath(internalApiBasePath);
 
         return internalApiClient;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 application.namespace="accounts-filing-api"
 api.base.path=${API_URL}
 internal.api.base.path=${INTERNAL_API_URL}
-internal.api.key=${CHS_INTERNAL_API_KEY}
-payments.api.base.path=${PAYMENTS_API_URL}
+internal.api.key=${CHS_API_KEY}
 spring.data.mongodb.uri=${MONGODB_URL}


### PR DESCRIPTION
This pr removes the payment url as we do not need it yet, and sets the internal key to the chs api key held in the vault.