### PR TITLE
Move the mongodb url into the vault for atlas integration

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -17,11 +17,13 @@ locals {
     "vpc_name"             = local.service_secrets["vpc_name"]
     "chs_api_key"          = local.service_secrets["chs_api_key"]
     "internal_api_url"     = local.service_secrets["internal_api_url"]
+    "mongodb_url"          = local.service_secrets["mongodb_url"]
   }
 
   vpc_name             = local.service_secrets["vpc_name"]
   chs_api_key          = local.service_secrets["chs_api_key"]
   internal_api_url     = local.service_secrets["internal_api_url"]
+  mongodb_url          = local.service_secrets["mongodb_url"]
 
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
@@ -37,13 +39,13 @@ locals {
 
   task_secrets = [
     { "name" : "CHS_API_KEY", "valueFrom" : "${local.service_secrets_arn_map.chs_api_key}" },
-    { "name" : "INTERNAL_API_URL", "valueFrom" : "${local.service_secrets_arn_map.internal_api_url}" }
+    { "name" : "INTERNAL_API_URL", "valueFrom" : "${local.service_secrets_arn_map.internal_api_url}" },
+    { "name" : "MONGODB_URL", "value" : "${local.service_secrets_arn_map.mongodb_url}" }
   ]
 
   task_environment = [
     { "name" : "API_URL", "value" : "${var.api_url}" },
     { "name" : "HUMAN_LOG", "value" : "${var.human_log}" },
-    { "name" : "LOG_LEVEL", "value" : "${var.log_level}" },
-    { "name" : "MONGODB_URL", "value" : "${var.mongodb_url}" }
+    { "name" : "LOG_LEVEL", "value" : "${var.log_level}" }
   ]
 }

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -3,4 +3,3 @@ aws_profile = "development-eu-west-2"
 
 api_url = "https://api.cidev.aws.chdev.org"
 log_level = "debug"
-mongodb_url = "mongodb://mongo/transactions_accounts"

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,4 +3,3 @@ aws_profile = "live-eu-west-2"
 
 api_url = "https://api.company-information.service.gov.uk"
 log_level = "info"
-mongodb_url = "mongodb://mongo/accounts_filing"

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -3,4 +3,3 @@ aws_profile = "staging-eu-west-2"
 
 api_url = "https://private-api-staging.company-information.service.gov.uk"
 log_level = "info"
-mongodb_url = "mongodb://mongo/accounts_filing"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -65,6 +65,3 @@ variable "human_log" {
   type    = string
   default = "1"
 }
-variable "mongodb_url" {
-    type = string
-}


### PR DESCRIPTION
This pr moves the mongodb_url variable into the vault as it is now a sensitive atlas url.