### PR TITLE
Fix group and weight in routes yaml file

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,6 +1,6 @@
 app_name: accounts-filing-api
-group: internalapi
-weight: 999998
+group: api
+weight: 500
 routes:
   1: ^/actuator/health
   2: ^/accounts-filing.*


### PR DESCRIPTION
This pr fixes the groups and weights in the routes.yaml file to fix the eric connection.