### PR TITLE
Enable the ERIC reverse proxy

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,8 +1,0 @@
-app_name: accounts-filing-api
-group: api
-weight: 500
-routes:
-  1: ^/actuator/health
-  2: ^/accounts-filing.*
-  3: ^/transactions/(.*)/accounts-filing/(.*)/.*
-

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -26,7 +26,7 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
 }
 
 data "aws_lb" "filing_maintain_lb" {
-  name = "${var.environment}-chs-apichgovuk"
+  name = "${var.environment}-chs-internalapi"
 }
 
 data "aws_lb_listener" "filing_maintain_lb_listener" {

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -10,6 +10,11 @@ locals {
   healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
   healthcheck_matcher       = "200"
 
+  # Enable Eric
+  use_eric_reverse_proxy  = true
+  eric_port               = "3001" # container port plus 1
+  eric_version            = "latest"
+
   kms_alias       = "alias/${var.aws_profile}/environment-services-kms"
   service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
 
@@ -47,5 +52,12 @@ locals {
     { "name" : "API_URL", "value" : "${var.api_url}" },
     { "name" : "HUMAN_LOG", "value" : "${var.human_log}" },
     { "name" : "LOG_LEVEL", "value" : "${var.log_level}" }
+  ]
+
+  eric_secrets = []
+
+  eric_environment = [
+    { "name": "LOGLEVEL", "value": "debug" },
+    { "name": "MODE", "value": "api" }
   ]
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -67,5 +67,14 @@ module "ecs-service" {
   task_environment = local.task_environment
   task_secrets     = local.task_secrets
 
+  # Eric variables
+  use_eric_reverse_proxy  = local.use_eric_reverse_proxy
+  eric_port               = local.eric_port
+  eric_version            = local.eric_version
+  eric_cpus               = var.required_cpus
+  eric_memory             = var.required_memory
+  eric_environment        = local.eric_environment
+  eric_secrets            = local.eric_secrets
+
   depends_on = [module.secrets]
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -20,7 +20,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.229git "
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.229"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -20,7 +20,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.197"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.229git "
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -29,7 +29,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.197"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.229"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
This pr enables the eric reverse proxy. An eric container will be spun up with the accounts filing api container. This pr includes the variables needed to enable it.

Also contained is a fix to use the internal load balancer as this app is internal only for now.