### PR TITLE
use parent-pom for dep check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>2.1.2</version>
+		<version>2.1.4</version>
 	</parent>
 	<artifactId>accounts-filing-api</artifactId>
 	<version>unversioned</version>
@@ -19,8 +19,6 @@
 		<spring-boot-maven-plugin.version>3.1.5</spring-boot-maven-plugin.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-
-		<dependency-check-plugin.version>8.2.1</dependency-check-plugin.version>
 
 		<!-- tests -->
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
@@ -351,18 +349,6 @@
 								<source>src/feature/java</source>
 							</sources>
 						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.owasp</groupId>
-				<artifactId>dependency-check-maven</artifactId>
-				<version>${dependency-check-plugin.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Cache results of previous builds per advice (https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#the-nvd-api-key-ci-and-rate-limiting)

Use parent pom to retrieve version and key for nvd api check rather than data feed.