### PR TITLE
Amend terraform to use env repo for configs

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -52,3 +52,14 @@ data "aws_ssm_parameter" "secret" {
   for_each = toset(data.aws_ssm_parameters_by_path.secrets.names)
   name     = each.key
 }
+
+# retrieve all global secrets for this env using global path
+data "aws_ssm_parameters_by_path" "global_secrets" {
+  path = "/${local.global_prefix}"
+}
+
+# create a list of secrets names to retrieve them in a nicer format and lookup each secret by name
+data "aws_ssm_parameter" "global_secret" {
+  for_each = toset(data.aws_ssm_parameters_by_path.global_secrets.names)
+  name     = each.key
+}

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -10,35 +10,19 @@ locals {
   healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
   healthcheck_matcher       = "200"
   application_subnet_ids    = data.aws_subnets.application.ids
+  stack_secrets             = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
+  application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
+  vpc_name                   = data.aws_ssm_parameter.secret[format("/%s/%s", local.name_prefix, "vpc-name")].value
+  kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"
+  service_secrets            = jsondecode(data.vault_generic_secret.service_secrets.data_json)
+  use_set_environment_files  = var.use_set_environment_files
+  app_environment_filename   = "accounts-filing-api.env"
 
   # Enable Eric
   use_eric_reverse_proxy  = true
   eric_port               = "3001" # container port plus 1
   eric_version            = "latest"
 
-  stack_secrets              = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
-  application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
-
-  kms_alias       = "alias/${var.aws_profile}/environment-services-kms"
-  service_secrets = jsondecode(data.vault_generic_secret.service_secrets.data_json)
-
-  parameter_store_secrets = {
-    "vpc_name"             = local.service_secrets["vpc_name"]
-    "chs_api_key"          = local.service_secrets["chs_api_key"]
-    "internal_api_url"     = local.service_secrets["internal_api_url"]
-    "mongodb_url"          = local.service_secrets["mongodb_url"]
-    "aes256_key"           = local.service_secrets["aes256_key"]
-    "api_key"              = local.service_secrets["api_key"]
-    "cache_url"            = local.service_secrets["cache_url"]
-  }
-
-  vpc_name             = local.service_secrets["vpc_name"]
-  chs_api_key          = local.service_secrets["chs_api_key"]
-  internal_api_url     = local.service_secrets["internal_api_url"]
-  mongodb_url          = local.service_secrets["mongodb_url"]
-  aes256_key           = local.service_secrets["aes256_key"]
-  api_key              = local.service_secrets["api_key"]
-  cache_url            = local.service_secrets["cache_url"]
 
   # create a map of secret name => secret arn to pass into ecs service module
   # using the trimprefix function to remove the prefixed path from the secret name
@@ -52,17 +36,37 @@ locals {
     trimprefix(sec.name, "/${local.service_name}-${var.environment}/") => sec.arn
   }
 
-  task_secrets = [
-    { "name" : "CHS_API_KEY", "valueFrom" : "${local.service_secrets_arn_map.chs_api_key}" },
-    { "name" : "INTERNAL_API_URL", "valueFrom" : "${local.service_secrets_arn_map.internal_api_url}" },
-    { "name" : "MONGODB_URL", "valueFrom" : "${local.service_secrets_arn_map.mongodb_url}" }
+  global_secret_list = flatten([for key, value in local.global_secrets_arn_map :
+    { "name" = upper(key), "valueFrom" = value }
+  ])
+
+  global_secrets_arn_map = {
+    for sec in data.aws_ssm_parameter.global_secret :
+    trimprefix(sec.name, "/${local.global_prefix}/") => sec.arn
+  }
+
+  service_secret_list = flatten([for key, value in local.service_secrets_arn_map :
+    { "name" = upper(key), "valueFrom" = value }
+  ])
+
+  ssm_service_version_map = [
+    for sec in module.secrets.secrets : {
+      name  = "${replace(upper(local.service_name), "-", "_")}_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}",
+      value = tostring(sec.version)
+    }
   ]
 
-  task_environment = [
-    { "name" : "API_URL", "value" : "${var.api_url}" },
-    { "name" : "HUMAN_LOG", "value" : "${var.human_log}" },
-    { "name" : "LOG_LEVEL", "value" : "${var.log_level}" }
+  ssm_global_version_map = [
+    for sec in data.aws_ssm_parameter.global_secret : {
+      name  = "GLOBAL_${var.ssm_version_prefix}${replace(upper(basename(sec.name)), "-", "_")}",
+      value = tostring(sec.version)
+    }
   ]
+
+  # secrets to go in list
+  task_secrets = concat(local.global_secret_list, local.service_secret_list)
+
+  task_environment = concat(local.ssm_global_version_map,local.ssm_service_version_map)
 
   eric_secrets = [
     { "name" : "AES256_KEY" , "valueFrom" : "${local.service_secrets_arn_map.aes256_key}" },

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -1,16 +1,17 @@
 # Define all hardcoded local variable and local variables looked up from data resources
 locals {
-  stack_name                = "filing-maintain" # this must match the stack name the service deploys into
-  name_prefix               = "${local.stack_name}-${var.environment}"
-  service_name              = "accounts-filing-api"
-  container_port            = "3000" # default port required here until prod docker container is built allowing port change via env var
-  docker_repo               = "accounts-filing-api"
-  lb_listener_rule_priority = 15
-  lb_listener_paths         = ["/accounts-filing/*", "/transactions/*/accounts-filing/*"]
-  healthcheck_path          = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
-  healthcheck_matcher       = "200"
-  application_subnet_ids    = data.aws_subnets.application.ids
-  stack_secrets             = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
+  stack_name                 = "filing-maintain" # this must match the stack name the service deploys into
+  name_prefix                = "${local.stack_name}-${var.environment}"
+  global_prefix              = "global-${var.environment}"
+  service_name               = "accounts-filing-api"
+  container_port             = "3000" # default port required here until prod docker container is built allowing port change via env var
+  docker_repo                = "accounts-filing-api"
+  lb_listener_rule_priority  = 15
+  lb_listener_paths          = ["/accounts-filing/*", "/transactions/*/accounts-filing/*"]
+  healthcheck_path           = "/accounts-filing/healthcheck" #healthcheck path for accounts-filing-api
+  healthcheck_matcher        = "200"
+  application_subnet_ids     = data.aws_subnets.application.ids
+  stack_secrets              = jsondecode(data.vault_generic_secret.stack_secrets.data_json)
   application_subnet_pattern = local.stack_secrets["application_subnet_pattern"]
   vpc_name                   = data.aws_ssm_parameter.secret[format("/%s/%s", local.name_prefix, "vpc-name")].value
   kms_alias                  = "alias/${var.aws_profile}/environment-services-kms"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -25,7 +25,7 @@ module "secrets" {
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
   kms_key_id  = data.aws_kms_key.kms_key.id
-  secrets     = local.parameter_store_secrets
+  secrets     = nonsensitive(local.service_secrets)
 }
 
 module "ecs-service" {

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -1,7 +1,7 @@
 environment = "cidev"
 aws_profile = "development-eu-west-2"
 
-api_url = "https://api.cidev.aws.chdev.org"
+use_set_environment_files = true
 log_level = "debug"
 
 # Eric Variables

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -99,6 +99,16 @@ variable "log_level" {
   type        = string
   description = "The log level for services to use: trace, debug, info or error"
 }
+variable "ssm_version_prefix" {
+  type        = string
+  description = "String to use as a prefix to the names of the variables containing variables and secrets version."
+  default     = "SSM_VERSION_"
+}
+variable "use_set_environment_files" {
+  type        = bool
+  default     = false
+  description = "Toggle default global and shared  environment files"
+}
 variable "api_url" {
   type = string
 }


### PR DESCRIPTION
This pr amends the terraform to use the latest locals code, including reading configs from the new ecs global configuration repo. This will fix a config issue in cidev where the payment api url is not present as it is in the global env.