### PR TITLE
Change getTransaction to use private endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionAPI.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionAPI.java
@@ -20,8 +20,6 @@ class TransactionAPI {
 
     private static final String PRIVATE_TRANSACTION_URL = "/private/transactions/";
 
-    private static final String TRANSACTION_URL = "/transactions/";
-
     @Autowired
     public TransactionAPI(ApiClientService apiClientService) {
         this.apiClientService = apiClientService;

--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionAPI.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionAPI.java
@@ -28,9 +28,8 @@ class TransactionAPI {
     }
 
     public ApiResponse<Transaction> get(final String transactionId) throws ApiErrorResponseException, URIValidationException {
-        String path = TRANSACTION_URL + transactionId;
-        TransactionsGet get = apiClientService.getApiKeyAuthenticatedClient().transactions()
-                .get(path);
+        String path = PRIVATE_TRANSACTION_URL + transactionId;
+        PrivateTransactionGet get = apiClientService.getInternalApiClient().privateTransaction().get(path);
         return get.execute();
     }
 

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionApiTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/service/transaction/TransactionApiTest.java
@@ -1,5 +1,9 @@
 package uk.gov.companieshouse.accounts.filing.service.transaction;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,40 +11,25 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 import uk.gov.companieshouse.accounts.filing.service.api.ApiClientService;
-import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.handler.privatetransaction.PrivateTransactionResourceHandler;
+import uk.gov.companieshouse.api.handler.privatetransaction.request.PrivateTransactionGet;
 import uk.gov.companieshouse.api.handler.privatetransaction.request.PrivateTransactionPatch;
-import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
-import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
-
-import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TransactionApiTest {
 
     private static final String TRANSACTION_ID = "00000-00000-00000";
-    private static final String TRANSACTION_URL = "/transactions/";
     private static final String PRIVATE_TRANSACTION_URL = "/private/transactions/";
 
     @Mock
     ApiClientService apiClientService;
 
     @Mock
-    ApiClient apiClient;
-
-    @Mock
-    TransactionsResourceHandler transactionsResourceHandler;
-
-    @Mock
-    TransactionsGet transactionsGet;
+    PrivateTransactionGet privateTransactionGet;
 
     @Mock
     InternalApiClient internalApiClient;
@@ -69,15 +58,15 @@ public class TransactionApiTest {
         Transaction transaction = new Transaction();
         ApiResponse<Transaction> expectedResponse = new ApiResponse<>(200, new HashMap<>(), transaction);
 
-        when(apiClientService.getApiKeyAuthenticatedClient()).thenReturn(apiClient);
-        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
-        when(transactionsResourceHandler.get(pathCaptor.capture())).thenReturn(transactionsGet);
-        when(transactionsGet.execute()).thenReturn(expectedResponse);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateTransaction()).thenReturn(privateTransactionResourceHandler);
+        when(privateTransactionResourceHandler.get(pathCaptor.capture())).thenReturn(privateTransactionGet);
+        when(privateTransactionGet.execute()).thenReturn(expectedResponse);
 
         ApiResponse<Transaction> actualResponse = transactionAPI.get(TRANSACTION_ID);
 
         assertEquals(expectedResponse.getStatusCode(), actualResponse.getStatusCode());
-        assertEquals(TRANSACTION_URL + TRANSACTION_ID, pathCaptor.getValue());
+        assertEquals(PRIVATE_TRANSACTION_URL + TRANSACTION_ID, pathCaptor.getValue());
     }
 
     @Test


### PR DESCRIPTION
Changes the getTransaction method to use the transaction api's private endpoints.
This is inline with other methods already existing in the service. 
The current implementation (using the regular, non private endpoints) fails due to the service not having OAUTH credentials.
This PR fixes this by changing to use the private endpoints just like the patch method already does. 

Required for: [AOAF-306](https://companieshouse.atlassian.net/browse/AOAF-306)

[AOAF-306]: https://companieshouse.atlassian.net/browse/AOAF-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ