### PR TITLE
Add logging when validation failed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingServiceImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.accounts.filing.service.accounts;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,6 +13,7 @@ import uk.gov.companieshouse.accounts.filing.model.AccountsFilingEntry;
 import uk.gov.companieshouse.accounts.filing.model.types.PackageType;
 import uk.gov.companieshouse.accounts.filing.repository.AccountsFilingRepository;
 import uk.gov.companieshouse.accounts.filing.utils.mapping.ImmutableConverter;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -38,23 +40,23 @@ public class AccountsFilingServiceImpl implements AccountsFilingService {
     public void savePackageType(AccountsFilingEntry accountsFilingEntry, String packageType) throws UriValidationException {
 
         accountsFilingEntry.setPackageType(PackageType.findPackageType(packageType));
-        
+
         accountsFilingRepository.save(accountsFilingEntry);
         var message = String.format("Account filing id: %s has been updated to include package type: %s",
-        accountsFilingEntry.getAccountsFilingId(), packageType);
+                accountsFilingEntry.getAccountsFilingId(), packageType);
         logger.debug(message);
     }
 
     @Override
     public AccountsFilingEntry getFilingEntry(String accountsFilingId) throws EntryNotFoundException {
         Optional<AccountsFilingEntry> optionalEntry = accountsFilingRepository.findById(accountsFilingId);
-        
+
         if (optionalEntry.isEmpty()) {
             var message = String.format("Entry with accountFilingId: %s was not found", accountsFilingId);
             logger.errorContext(accountsFilingId, message, null, ImmutableConverter.toMutableMap(Map.of(
-                "expected", "accountsFilingEntry Object",
-                "status", "empty optional"
-                )));
+                    "expected", "accountsFilingEntry Object",
+                    "status", "empty optional"
+            )));
             throw new EntryNotFoundException(message);
         }
         return optionalEntry.get();
@@ -62,29 +64,54 @@ public class AccountsFilingServiceImpl implements AccountsFilingService {
 
     /**
      * This method used to validate the data in accounts filing entry
+     *
      * @param accountsFilingEntry - accounts filing entry which needs to be validated
      * @return ValidationStatusResponse - Contains the validation status of the accounts filing entry
      */
     @Override
-    public ValidationStatusResponse validateAccountsFilingEntry(AccountsFilingEntry accountsFilingEntry){
-        return accountsFilingValidator.validateAccountsFilingEntry(accountsFilingEntry);
+    public ValidationStatusResponse validateAccountsFilingEntry(AccountsFilingEntry accountsFilingEntry) {
+        var validationStatus = accountsFilingValidator.validateAccountsFilingEntry(accountsFilingEntry);
+
+        if (!validationStatus.isValid()) {
+            logValidationFailed(accountsFilingEntry.getAccountsFilingId(), validationStatus);
+        }
+
+        return validationStatus;
     }
+
+    private void logValidationFailed(String accountsFilingId, ValidationStatusResponse validationStatusResponse) {
+        var logData = new HashMap<String, Object>();
+        var errors = validationStatusResponse.getValidationStatusError();
+
+        logData.put("numValidationErrors", errors.length);
+
+        for (int i = 0; i < errors.length; i++) {
+            logData.put(String.format("validationError[%d]", i), formatValidationError(errors[i]));
+        }
+
+        logger.errorContext(accountsFilingId, "Accounts failed validation", null, logData);
+    }
+
+    private String formatValidationError(ValidationStatusError error) {
+        return String.format("Field: %s, Error: %s", error.getLocation(), error.getError());
+    }
+
 
     /**
      * This method used to get the accounts filing entry for the given transaction id and accounts filing id
-     * @param transactionId - ID of the transaction
+     *
+     * @param transactionId    - ID of the transaction
      * @param accountsFilingId - Filing id of the accounts
      * @return AccountsFilingEntry - returns accounts filing entry  for the given transaction id and accounts filing id.
      */
     @Override
     public AccountsFilingEntry getAccountsFilingEntryForIDAndTransaction(String transactionId, String accountsFilingId) {
         AccountsFilingEntry accountsFilingEntry = getFilingEntry(accountsFilingId);
-        if(transactionId != null && transactionId.equals(accountsFilingEntry.getTransactionId())){
+        if (transactionId != null && transactionId.equals(accountsFilingEntry.getTransactionId())) {
             return accountsFilingEntry;
-        }
-        else{
+        } else {
             var message = String.format("Entry with accountFilingId: %s and transaction id: %s was not found",
-                                                        accountsFilingId, transactionId);
+                    accountsFilingId, transactionId);
             logger.error(message);
             throw new EntryNotFoundException(message);
         }

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.accounts.filing.exceptionhandler.EntryNotFoundExcep
 import uk.gov.companieshouse.accounts.filing.exceptionhandler.UriValidationException;
 import uk.gov.companieshouse.accounts.filing.model.AccountsFilingEntry;
 import uk.gov.companieshouse.accounts.filing.repository.AccountsFilingRepository;
+import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusError;
 import uk.gov.companieshouse.api.model.validationstatus.ValidationStatusResponse;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -94,6 +95,7 @@ class AccountsFilingServiceTest {
         var accountFilingId = "accountsFilingId";
         AccountsFilingEntry entry = new AccountsFilingEntry(accountFilingId);
         ValidationStatusResponse validationStatusResponse = new ValidationStatusResponse();
+        validationStatusResponse.setValidationStatusError(new ValidationStatusError[0]);
 
         validationStatusResponse.setValid(false);
         when(accountsFilingValidator.validateAccountsFilingEntry(entry)).thenReturn(validationStatusResponse);


### PR DESCRIPTION
Add logging for the case for when validation of a transaction fails in the `/validation_status` endpoint which is called by the transactions API.
This is to help debug issues when a transaction fails validation.