### PR TITLE
Prevent logging on healthcheck endpoint

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/WebMvcConfig.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/WebMvcConfig.java
@@ -39,7 +39,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(loggingInterceptor);
+        registry.addInterceptor(loggingInterceptor)
+                .excludePathPatterns("/accounts-filing/healthcheck");
         registry.addInterceptor(internalUserInterceptor)
                 .excludePathPatterns("/accounts-filing/healthcheck");
         addAccountsFilingIdInterceptor(registry);


### PR DESCRIPTION
Prevent a log appearing when the healthcheck endpoint is hit as this was causing log pollution, making debugging hard.