### PR TITLE
Revert back to ecs service version 253

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -18,7 +18,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.260"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.253"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -27,7 +27,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.260"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.253"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
This is because of compatibilty issues with eric set up after 254.