### PR TITLE
Make filings GET return an array to match spec

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/controller/PrivateTransactionController.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/controller/PrivateTransactionController.java
@@ -34,7 +34,7 @@ public class PrivateTransactionController {
     }
 
     @GetMapping("/filings")
-    public ResponseEntity<FilingApi> getFilingApiEntry(
+    public ResponseEntity<FilingApi[]> getFilingApiEntry(
             @PathVariable("transactionId") final String transactionId,
             @PathVariable("accountsFilingId") final String accountsFilingId) {
 
@@ -42,8 +42,8 @@ public class PrivateTransactionController {
 
             AccountsFilingEntry accountsFilingEntry = accountsFilingService
                     .getAccountsFilingEntryForIDAndTransaction(transactionId, accountsFilingId);
-
-            return ResponseEntity.ok(filingGeneratorMapper.mapToFilingApi(accountsFilingEntry));
+            FilingApi filingApi = filingGeneratorMapper.mapToFilingApi(accountsFilingEntry);
+            return ResponseEntity.ok(new FilingApi[]{ filingApi });
 
         } catch (EntryNotFoundException ex) {
             logger.error(String.format("%s: did not match a known accountFilingId", accountsFilingId));

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/controller/PrivateTransactionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/controller/PrivateTransactionControllerTest.java
@@ -38,8 +38,8 @@ class PrivateTransactionControllerTest {
 
     private final static String accountsFilingId = "accountFilingId";
 
-    @Mock
-    AccountsFilingEntry accountsFilingEntry;
+    private final static AccountsFilingEntry accountsFilingEntry = new AccountsFilingEntry("1");
+    private final static FilingApi filingApi = new FilingApi();
 
     @BeforeEach
     void beforeEach() {
@@ -52,17 +52,19 @@ class PrivateTransactionControllerTest {
 
         when(accountsFilingService
         .getAccountsFilingEntryForIDAndTransaction(transactionId, accountsFilingId)).thenThrow(EntryNotFoundException.class);
-        ResponseEntity<FilingApi> result = controller.getFilingApiEntry(transactionId, accountsFilingId);
+        ResponseEntity<FilingApi[]> result = controller.getFilingApiEntry(transactionId, accountsFilingId);
         assertEquals(HttpStatusCode.valueOf(404), result.getStatusCode());
     }
 
     @Test
     @DisplayName("Test with valid inputs")
     void testGetFilingApi() {
-        when(accountsFilingService
-        .getAccountsFilingEntryForIDAndTransaction(transactionId, accountsFilingId)).thenReturn(accountsFilingEntry);
-        ResponseEntity<FilingApi> result = controller.getFilingApiEntry(transactionId, accountsFilingId);
+        when(accountsFilingService.getAccountsFilingEntryForIDAndTransaction(transactionId, accountsFilingId))
+                .thenReturn(accountsFilingEntry);
+        when(filingGeneratorMapper.mapToFilingApi(accountsFilingEntry)).thenReturn(filingApi);
+        ResponseEntity<FilingApi[]> result = controller.getFilingApiEntry(transactionId, accountsFilingId);
         assertEquals(HttpStatusCode.valueOf(200), result.getStatusCode());
+        assertEquals(filingApi, result.getBody()[0]);
     }
 
 }


### PR DESCRIPTION
This pr changes the return of the filing generator endpoint to be a singleton array of filings. This is because the filing resource generator expects an array.