### PR TITLE
Fix kind in filing generator to match chips type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
@@ -30,7 +30,7 @@ public class FilingGeneratorMapper {
         filingApiEntity.setDescription("Package accounts made up to " + madeUpDate);
         filingApiEntity.setDescriptionIdentifier(getAccountTypeName(accountsFilingEntry));
         filingApiEntity.setDescriptionValues(descriptionValue);
-        filingApiEntity.setKind("package-accounts");
+        filingApiEntity.setKind("accounts");
         filingApiEntity.setData(mapData(accountsFilingEntry, madeUpDate));
 
         return filingApiEntity;

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
@@ -56,7 +56,7 @@ class FilingGeneratorMapperTest {
         assertEquals("Package accounts made up to "+madeUpDate, filingApi.getDescription());
         assertEquals("AUDITED FULL", filingApi.getDescriptionIdentifier());
         assertEquals(Collections.singletonMap("made up date", madeUpDate), filingApi.getDescriptionValues());
-        assertEquals("package-accounts", filingApi.getKind());
+        assertEquals("accounts", filingApi.getKind());
         assertEquals(PackageTypeApi.UKSEF.toString(), filingApi.getData().get("packageType"));
         assertEquals(accountsType, filingApi.getData().get("accountsType"));
         assertEquals(createLinks(), filingApi.getData().get("links"));


### PR DESCRIPTION
This pr changes the kind variable returned to the filing generator to "accounts". This is so the chips filing consumer will know this is an accounts form.