### PR TITLE
Match filing generator endpoint format to chips filing consumer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.accounts.filing.mapper;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -42,19 +43,19 @@ public class FilingGeneratorMapper {
 
     private Map<String, Object> mapData(AccountsFilingEntry accountsFilingEntry, String madeUpDate) {
         Map<String, Object> data = new HashMap<>();
-        data.put("packageType", accountsFilingEntry.getPackageType().toString());
-        data.put("accountsType", accountsFilingEntry.getAccountsType());
-        data.put("links", mapLocation(accountsFilingEntry));
-        data.put("madeUpDate", madeUpDate);
+        data.put("package_type", accountsFilingEntry.getPackageType().toString());
+        data.put("accounts_type", accountsFilingEntry.getAccountsType());
+        data.put("links", mapLinks(accountsFilingEntry));
+        data.put("period_end_on", madeUpDate);
         return data;
     }
 
-    private Map<String, String> mapLocation(AccountsFilingEntry accountsFilingEntry) {
+    private List<Map<String, String>> mapLinks(AccountsFilingEntry accountsFilingEntry) {
         Map<String, String> location = new HashMap<>();
         location.put("rel", "accounts");
         // The file id location
         location.put("href", String.format("%s%s/%s", scheme, bucket, accountsFilingEntry.getFileId()));
-        return location;
+        return List.of(location);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
@@ -1,9 +1,10 @@
 package uk.gov.companieshouse.accounts.filing.mapper;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +23,7 @@ class FilingGeneratorMapperTest {
 
     private final static String madeUpDate = "now";
     private final static String accountsType = "01";
-    private static Map<String, String> links;
+    private static List<Map<String, String>> links;
 
     private AccountsFilingEntry createAccountsFilingEntry() {
         var filingEntry = new AccountsFilingEntry("accountFilingId");
@@ -33,11 +34,11 @@ class FilingGeneratorMapperTest {
         return filingEntry;
     }
 
-    private Map<String, String> createLinks() {
-        links = new HashMap<>();
+    private List<Map<String, String>> createLinks() {
+        Map<String, String> links = new HashMap<>();
         links.put("rel", "accounts");
         links.put("href", "schemebucket/fileId");
-        return links;
+        return List.of(links);
     }
 
     @BeforeEach
@@ -46,21 +47,20 @@ class FilingGeneratorMapperTest {
         ReflectionTestUtils.setField(filingGeneratorMapper, "bucket", "bucket");
         ReflectionTestUtils.setField(filingGeneratorMapper, "scheme", "scheme");
         links = createLinks();
-        
     }
 
     @Test
     void testMapToFilingApi() {
         accountsFilingEntry = createAccountsFilingEntry();
         FilingApi filingApi = filingGeneratorMapper.mapToFilingApi(accountsFilingEntry);
-        assertEquals("Package accounts made up to "+madeUpDate, filingApi.getDescription());
+        assertEquals("Package accounts made up to " + madeUpDate, filingApi.getDescription());
         assertEquals("AUDITED FULL", filingApi.getDescriptionIdentifier());
         assertEquals(Collections.singletonMap("made up date", madeUpDate), filingApi.getDescriptionValues());
         assertEquals("accounts", filingApi.getKind());
-        assertEquals(PackageTypeApi.UKSEF.toString(), filingApi.getData().get("packageType"));
-        assertEquals(accountsType, filingApi.getData().get("accountsType"));
+        assertEquals(PackageTypeApi.UKSEF.toString(), filingApi.getData().get("package_type"));
+        assertEquals(accountsType, filingApi.getData().get("accounts_type"));
         assertEquals(createLinks(), filingApi.getData().get("links"));
-        assertEquals(madeUpDate, filingApi.getData().get("madeUpDate"));
+        assertEquals(madeUpDate, filingApi.getData().get("period_end_on"));
         
     }
 


### PR DESCRIPTION
This pr fixes three elements to the data returned from the filing generator endpoint so that it matches the format required by the chips-filing-consumer
1. The links are now held in an array
2. The json keys are in snake case
3. The made up date key is the period_end_on as this matches the return from the web services.