### PR TITLE
Use oauth2 interceptor instead of api key

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/ApplicationConfiguration.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.accounts.filing.configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
@@ -40,16 +39,4 @@ public class ApplicationConfiguration {
 
         return internalApiClient;
     }
-
-
-    /**
-     * Creates InternalUserInterceptor which checks the Api key has internal app privileges to access the application
-     *
-     * @return the internal user interceptor
-     */
-    @Bean
-    public InternalUserInterceptor internalUserInterceptor() {
-        return new InternalUserInterceptor(applicationNameSpace);
-    }
-
 }


### PR DESCRIPTION
This pr changes the interceptor configuration to use OAuth2 instead of an api key. This is because:
- It is the standard
- It will enable to confirmation email to work

This pr in linked to a permission change pr:
https://github.com/companieshouse/account.ch.gov.uk/pull/468