### PR TITLE
Use internal api key interceptor for private endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/WebMvcConfig.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/configuration/WebMvcConfig.java
@@ -44,7 +44,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor)
-                .excludePathPatterns("/accounts-filing/healthcheck");
+                .excludePathPatterns(HEALTHCHECK_URI);
         registry.addInterceptor(getUserCrudAuthenticationInterceptor())
                 .excludePathPatterns(OAUTH2_EXCLUDE);
         registry.addInterceptor(getCompanyCrudAuthenticationInterceptor())


### PR DESCRIPTION
This pr changes the interceptor registry so private urls use an internal api key instead of a OAuth2. This is to fix a bug with the filing generator endpoint failing as it uses an api key instead of OAuth2.