### PR TITLE
AOAF- Allow MUD to be null for overseas submissions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
@@ -97,7 +97,7 @@ public class AccountsFilingValidator {
         final String madeUpDateMessage = "MadeUpDate : " + madeUpDate;
 
         if (madeUpDate == null || madeUpDate.isBlank()) {
-            if(isOverseas){
+            if (isOverseas) {
                 return;
             }
             setValidationError(validationStatusErrors, madeUpDateMessage,

--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
@@ -31,11 +31,7 @@ public class AccountsFilingValidator {
 
         validatePackageType(accountsFilingEntry.getPackageType(), validationStatusErrors);
         validateAccountsType(accountsFilingEntry.getAccountsType(), validationStatusErrors);
-        if(PackageTypeApi.OVERSEAS == accountsFilingEntry.getPackageType()){
-            validateMadeUpDateForOverseas(accountsFilingEntry.getMadeUpDate(), validationStatusErrors);
-        }else{
-            validateMadeUpDate(accountsFilingEntry.getMadeUpDate(), validationStatusErrors);
-        }
+        validateMadeUpDate(accountsFilingEntry.getMadeUpDate(), validationStatusErrors, PackageTypeApi.OVERSEAS == accountsFilingEntry.getPackageType());
         validateFileId(accountsFilingEntry.getFileId(), validationStatusErrors);
 
         final boolean passedValidation = validationStatusErrors.isEmpty();
@@ -96,45 +92,18 @@ public class AccountsFilingValidator {
      *                               entry
      * @param validationStatusErrors - List which holds the validation errors
      */
-    private void validateMadeUpDate(final String madeUpDate, final List<ValidationStatusError> validationStatusErrors) {
+    private void validateMadeUpDate(final String madeUpDate, final List<ValidationStatusError> validationStatusErrors, boolean isOverseas) {
 
         final String madeUpDateMessage = "MadeUpDate : " + madeUpDate;
 
         if (madeUpDate == null || madeUpDate.isBlank()) {
+            if(isOverseas){
+                return;
+            }
             setValidationError(validationStatusErrors, madeUpDateMessage,
                     "Made up date is null or blank");
             return;
         }
-        if ("UNKNOWN".equals(madeUpDate)) {
-            setValidationError(validationStatusErrors, madeUpDateMessage,
-                    "Made up date is unknown");
-            return;
-        }
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        dateFormat.setLenient(false);
-        try {
-            dateFormat.parse(madeUpDate);
-        } catch (final ParseException parseException) {
-            setValidationError(validationStatusErrors, madeUpDateMessage,
-                    "Made up date is not in yyyy-MM-dd format");
-        }
-    }
-    /**
-     * This method validates the made up date is valid or not for overseas
-     *
-     * @param madeUpDate             - made up date of the given accounts filing
-     *                               entry
-     * @param validationStatusErrors - List which holds the validation errors
-     */
-    private void validateMadeUpDateForOverseas(final String madeUpDate, final List<ValidationStatusError> validationStatusErrors) {
-
-        final String madeUpDateMessage = "MadeUpDate : " + madeUpDate;
-
-        if (madeUpDate == null || madeUpDate.isBlank()) {
-            return;
-        }
-
         if ("UNKNOWN".equals(madeUpDate)) {
             setValidationError(validationStatusErrors, madeUpDateMessage,
                     "Made up date is unknown");

--- a/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidator.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import static uk.gov.companieshouse.api.model.felixvalidator.PackageTypeApi.OVERSEAS;
+
 @Component
 public class AccountsFilingValidator {
 
@@ -29,7 +31,11 @@ public class AccountsFilingValidator {
 
         validatePackageType(accountsFilingEntry.getPackageType(), validationStatusErrors);
         validateAccountsType(accountsFilingEntry.getAccountsType(), validationStatusErrors);
-        validateMadeUpDate(accountsFilingEntry.getMadeUpDate(), validationStatusErrors);
+        if(PackageTypeApi.OVERSEAS == accountsFilingEntry.getPackageType()){
+            validateMadeUpDateForOverseas(accountsFilingEntry.getMadeUpDate(), validationStatusErrors);
+        }else{
+            validateMadeUpDate(accountsFilingEntry.getMadeUpDate(), validationStatusErrors);
+        }
         validateFileId(accountsFilingEntry.getFileId(), validationStatusErrors);
 
         final boolean passedValidation = validationStatusErrors.isEmpty();
@@ -99,6 +105,36 @@ public class AccountsFilingValidator {
                     "Made up date is null or blank");
             return;
         }
+        if ("UNKNOWN".equals(madeUpDate)) {
+            setValidationError(validationStatusErrors, madeUpDateMessage,
+                    "Made up date is unknown");
+            return;
+        }
+        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.UK);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dateFormat.setLenient(false);
+        try {
+            dateFormat.parse(madeUpDate);
+        } catch (final ParseException parseException) {
+            setValidationError(validationStatusErrors, madeUpDateMessage,
+                    "Made up date is not in yyyy-MM-dd format");
+        }
+    }
+    /**
+     * This method validates the made up date is valid or not for overseas
+     *
+     * @param madeUpDate             - made up date of the given accounts filing
+     *                               entry
+     * @param validationStatusErrors - List which holds the validation errors
+     */
+    private void validateMadeUpDateForOverseas(final String madeUpDate, final List<ValidationStatusError> validationStatusErrors) {
+
+        final String madeUpDateMessage = "MadeUpDate : " + madeUpDate;
+
+        if (madeUpDate == null || madeUpDate.isBlank()) {
+            return;
+        }
+
         if ("UNKNOWN".equals(madeUpDate)) {
             setValidationError(validationStatusErrors, madeUpDateMessage,
                     "Made up date is unknown");

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidatorTest.java
@@ -195,7 +195,7 @@ class AccountsFilingValidatorTest {
     }
 
     @Test
-    @DisplayName("Testing failed accounts filing data with different made up dates")
+    @DisplayName("Testing passed accounts filing data with different made up dates")
     void testPassedMadeUpDate() {
         entry.setPackageType(PackageTypeApi.UKSEF);
         entry.setAccountsType("09");
@@ -210,7 +210,7 @@ class AccountsFilingValidatorTest {
             "null,Made up date is null or blank",
             "'',Made up date is null or blank"
     }, nullValues = "null")
-    @DisplayName("Testing failed accounts filing data with different made up dates")
+    @DisplayName("Testing passed accounts filing data for overseas with made up dates either to be null or blank")
     void testPassedMadeUpDateForOverseas(String madeUpDate) {
         entry.setPackageType(PackageTypeApi.OVERSEAS);
         entry.setAccountsType("09");

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/service/accounts/AccountsFilingValidatorTest.java
@@ -175,6 +175,25 @@ class AccountsFilingValidatorTest {
 
     }
 
+    @ParameterizedTest
+    @CsvSource(value = {
+            "UNKNOWN,Made up date is unknown",
+            "MadeUpDate,Made up date is not in yyyy-MM-dd format",
+            "2018-30-30,Made up date is not in yyyy-MM-dd format",
+            "06-06-2013,Made up date is not in yyyy-MM-dd format"
+    }, nullValues = "null")
+    @DisplayName("Testing failed accounts filing data with different made up dates")
+    void testFailedValidateAccountsFilingEntryWithDifferentMadeUpDateForOverseas(String madeUpDate, String errorMessage) {
+        entry.setPackageType(PackageTypeApi.OVERSEAS);
+        entry.setAccountsType("09");
+        entry.setFileId("9df3ddab-c199-467e-80d6-40405b1c824a");
+
+        entry.setMadeUpDate(madeUpDate);
+        validateAccountsFilingEntry(entry);
+        assertValidationCheckWithOneErrorForMUDForOverseas(
+                errorMessage);
+    }
+
     @Test
     @DisplayName("Testing failed accounts filing data with different made up dates")
     void testPassedMadeUpDate() {
@@ -182,6 +201,21 @@ class AccountsFilingValidatorTest {
         entry.setAccountsType("09");
         entry.setFileId("9df3ddab-c199-467e-80d6-40405b1c824a");
         entry.setMadeUpDate("2018-06-30");
+        validateAccountsFilingEntry(entry);
+        assertValidationSuccessful();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "null,Made up date is null or blank",
+            "'',Made up date is null or blank"
+    }, nullValues = "null")
+    @DisplayName("Testing failed accounts filing data with different made up dates")
+    void testPassedMadeUpDateForOverseas(String madeUpDate) {
+        entry.setPackageType(PackageTypeApi.OVERSEAS);
+        entry.setAccountsType("09");
+        entry.setFileId("9df3ddab-c199-467e-80d6-40405b1c824a");
+        entry.setMadeUpDate(madeUpDate);
         validateAccountsFilingEntry(entry);
         assertValidationSuccessful();
     }
@@ -248,6 +282,14 @@ class AccountsFilingValidatorTest {
     }
 
     void assertValidationFailedWithOneError(String expectedErrorMessage) {
+        assertFalse(validationStatusResponse.isValid());
+        assertNotNull(validationStatusResponse.getValidationStatusError());
+        assertEquals(1, validationStatusResponse.getValidationStatusError().length);
+        ValidationStatusError validationStatusError = validationStatusResponse.getValidationStatusError()[0];
+        assertEquals(expectedErrorMessage, validationStatusError.getError());
+        assertNotNull(validationStatusError.getType());
+    }
+    void assertValidationCheckWithOneErrorForMUDForOverseas(String expectedErrorMessage) {
         assertFalse(validationStatusResponse.isValid());
         assertNotNull(validationStatusResponse.getValidationStatusError());
         assertEquals(1, validationStatusResponse.getValidationStatusError().length);

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/service/file/validation/AccountsValidationServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/service/file/validation/AccountsValidationServiceTest.java
@@ -107,12 +107,12 @@ class AccountsValidationServiceTest {
         String accountType = "accountType";
         String fileName = "fileName";
         String balanceSheetDate = "2021-01-30";
-        String registationNumber = "0";
+        String registrationNumber = "0";
         AccountsValidatorValidationStatusApi validationStatus = AccountsValidatorValidationStatusApi.OK;
         AccountsFilingEntry accountsFilingEntryRequest = new AccountsFilingEntry(accountFilingId);
         accountsFilingEntryRequest.setPackageType(PackageTypeApi.UKSEF);
 
-        AccountsValidatorDataApi accountsValidatorStatusApi = createAccountsValidatorDataApi(balanceSheetDate, accountType, registationNumber);
+        AccountsValidatorDataApi accountsValidatorStatusApi = createAccountsValidatorDataApi(balanceSheetDate, accountType, registrationNumber);
         AccountsValidatorStatusApi accountsValidatorStatus = createAccountsValidatorStatusApi(fileId, fileName, accountStatus, 
                                                                                               validationStatus, accountsValidatorStatusApi);
 
@@ -134,12 +134,12 @@ class AccountsValidationServiceTest {
         String accountType = "accountType";
         String fileName = "fileName";
         String balanceSheetDate = "2021-01-30";
-        String registationNumber = "0";
+        String registrationNumber = "0";
         AccountsValidatorValidationStatusApi validationStatus = AccountsValidatorValidationStatusApi.OK;
         AccountsFilingEntry accountsFilingEntryRequest = new AccountsFilingEntry(accountFilingId);
         accountsFilingEntryRequest.setPackageType(PackageTypeApi.GROUP_PACKAGE_400);
 
-        AccountsValidatorDataApi accountsValidatorStatusApi = createAccountsValidatorDataApi(balanceSheetDate, accountType, registationNumber);
+        AccountsValidatorDataApi accountsValidatorStatusApi = createAccountsValidatorDataApi(balanceSheetDate, accountType, registrationNumber);
         AccountsValidatorStatusApi accountsValidatorStatus = createAccountsValidatorStatusApi(fileId, fileName, accountStatus,
                 validationStatus, accountsValidatorStatusApi);
 
@@ -183,10 +183,10 @@ class AccountsValidationServiceTest {
     @DisplayName("Call validation check but 4xx request")
     void testValidationStatusResultUserIssue() throws ApiErrorResponseException, URIValidationException {
         String fileId = "fileId";
-        ApiErrorResponseException responseExcetion = mock(ApiErrorResponseException.class);
+        ApiErrorResponseException responseException = mock(ApiErrorResponseException.class);
         
-        when(responseExcetion.getStatusCode()).thenReturn(401);
-        when(api.getValidationCheck(fileId)).thenThrow(responseExcetion);
+        when(responseException.getStatusCode()).thenReturn(401);
+        when(api.getValidationCheck(fileId)).thenThrow(responseException);
 
         assertThrows(ResponseException.class, () -> service.validationStatusResult(fileId));
     }
@@ -195,10 +195,10 @@ class AccountsValidationServiceTest {
     @DisplayName("Call validation check but external issue occurs")
     void testValidationStatusResultUnexpectedResponse() throws ApiErrorResponseException, URIValidationException {
         String fileId = "fileId";
-        ApiErrorResponseException responseExcetion = mock(ApiErrorResponseException.class);
+        ApiErrorResponseException responseException = mock(ApiErrorResponseException.class);
         
-        when(responseExcetion.getStatusCode()).thenReturn(500);
-        when(api.getValidationCheck(fileId)).thenThrow(responseExcetion);
+        when(responseException.getStatusCode()).thenReturn(500);
+        when(api.getValidationCheck(fileId)).thenThrow(responseException);
 
         assertThrows(ExternalServiceException.class, () -> service.validationStatusResult(fileId));
     }


### PR DESCRIPTION
- Put a condition for overseas submission
- add a new method  `validateMadeUpDateForOverseas` to validate MUD for oversea submission
- update the request test classes.

