### PR TITLE
Include the cost in the filing, so the refund process picks it up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- internal -->
         <structured-logging.version>3.0.1</structured-logging.version>
         <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>4.0.258</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.268</private-api-sdk-java.version>
         <api-security-java-version>2.0.8</api-security-java-version>
 
         <!--sonar configuration-->

--- a/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapper.java
@@ -24,6 +24,12 @@ public class FilingGeneratorMapper {
     @Value("${file.scheme}")
     private String scheme;
 
+    @Value("${fee.cic.accounts}")
+    private String cicCost;
+
+    @Value("${fee.overseas.accounts}")
+    private String overseasCost;
+
     public FilingApi mapToFilingApi(AccountsFilingEntry accountsFilingEntry) {
 
         var madeUpDate = accountsFilingEntry.getMadeUpDate();
@@ -31,10 +37,16 @@ public class FilingGeneratorMapper {
         Map<String, String> descriptionValue = Collections.singletonMap("made up date", madeUpDate);
 
         var filingApiEntity = new FilingApi();
-        if (PackageTypeApi.OVERSEAS == accountsFilingEntry.getPackageType()) {
-            filingApiEntity.setDescription("Package accounts with package type overseas");
-        } else {
-            filingApiEntity.setDescription("Package accounts made up to " + formatMadeUpDate(madeUpDate));
+        switch (accountsFilingEntry.getPackageType()) {
+            case PackageTypeApi.OVERSEAS:
+                filingApiEntity.setCost(overseasCost);
+                filingApiEntity.setDescription("Package accounts with package type overseas");
+                break;
+            case PackageTypeApi.CIC:
+                filingApiEntity.setCost(cicCost);
+            default:
+                filingApiEntity.setDescription("Package accounts made up to " + formatMadeUpDate(madeUpDate));
+                break;
         }
 
         filingApiEntity.setDescriptionIdentifier(getAccountTypeName(accountsFilingEntry));

--- a/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/filing/mapper/FilingGeneratorMapperTest.java
@@ -26,6 +26,8 @@ class FilingGeneratorMapperTest {
     private final static String madeUpDate = "2000-01-01";
     private final static String madeUpDateFormatted = "1 January 2000";
     private final static String accountsType = "01";
+    private final static String CIC_COST = "20.00";
+    private final static String OVERSEAS_COST = "30.00";
     private static List<Map<String, String>> links;
 
     private AccountsFilingEntry createAccountsFilingEntry() {
@@ -49,6 +51,8 @@ class FilingGeneratorMapperTest {
         filingGeneratorMapper = new FilingGeneratorMapper();
         ReflectionTestUtils.setField(filingGeneratorMapper, "bucket", "bucket");
         ReflectionTestUtils.setField(filingGeneratorMapper, "scheme", "scheme");
+        ReflectionTestUtils.setField(filingGeneratorMapper, "cicCost", CIC_COST);
+        ReflectionTestUtils.setField(filingGeneratorMapper, "overseasCost", OVERSEAS_COST);
         links = createLinks();
     }
 
@@ -80,7 +84,24 @@ class FilingGeneratorMapperTest {
         assertEquals(PackageTypeApi.OVERSEAS.toString(), filingApi.getData().get("package_type"));
         assertEquals(accountsType, filingApi.getData().get("accounts_type"));
         assertEquals(createLinks(), filingApi.getData().get("links"));
+        assertEquals(OVERSEAS_COST, filingApi.getCost());
         assertNull(filingApi.getData().get("period_end_on"));
+    }
+
+    @Test
+    void testMapToFilingApiWhenPackageTypeIsCIC() {
+        accountsFilingEntry = createAccountsFilingEntry();
+        accountsFilingEntry.setPackageType(PackageTypeApi.CIC);
+        FilingApi filingApi = filingGeneratorMapper.mapToFilingApi(accountsFilingEntry);
+        assertEquals("Package accounts made up to " + madeUpDateFormatted, filingApi.getDescription());
+        assertEquals("AUDITED FULL", filingApi.getDescriptionIdentifier());
+        assertEquals(Collections.singletonMap("made up date", madeUpDate), filingApi.getDescriptionValues());
+        assertEquals("accounts", filingApi.getKind());
+        assertEquals(PackageTypeApi.CIC.toString(), filingApi.getData().get("package_type"));
+        assertEquals(accountsType, filingApi.getData().get("accounts_type"));
+        assertEquals(createLinks(), filingApi.getData().get("links"));
+        assertEquals(madeUpDate, filingApi.getData().get("period_end_on"));
+        assertEquals(CIC_COST, filingApi.getCost());
     }
 
     @Test


### PR DESCRIPTION
This pr includes the setting of the cost property on the filing object for cic and overseas submissions. This is so the transaction api finds the cost in the filing when it's checking to see if the submission is refundable.

**Required for:**
- [AOAF-667](https://companieshouse.atlassian.net/browse/AOAF-667)

[AOAF-667]: https://companieshouse.atlassian.net/browse/AOAF-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ